### PR TITLE
prevent sending UIControl events twice

### DIFF
--- a/Sources/ColorSlider.swift
+++ b/Sources/ColorSlider.swift
@@ -207,8 +207,9 @@ import CoreGraphics
         updateForTouch(endTouch, touchInside: isTouchInside)
 		
         removePreview()
-		
-		sendActions(for: isTouchInside ? .touchUpInside : .touchUpOutside)
+
+		guard !isTouchInside else { return }
+		sendActions(for: .touchUpOutside)
     }
 	
 	/// Cancels tracking a touch when the user cancels dragging on the `ColorSlider`.


### PR DESCRIPTION
This commit is to prevent sending UIControl events twice.
This is a known issue, as can be seen [here](http://stackoverflow.com/questions/1063158/uislider-returns-two-touch-up-inside-events-why-does-that-happen)